### PR TITLE
Removed redundant virtual and regenerated with latest ridlc

### DIFF
--- a/examples/array/testC.h
+++ b/examples/array/testC.h
@@ -6,8 +6,8 @@
  *        https://www.remedy.nl
  */
 
-#ifndef __RIDL_TESTC_H_IIJHJCAI_INCLUDED__
-#define __RIDL_TESTC_H_IIJHJCAI_INCLUDED__
+#ifndef __RIDL_TESTC_H_EDCGBBEG_INCLUDED__
+#define __RIDL_TESTC_H_EDCGBBEG_INCLUDED__
 
 #pragma once
 
@@ -427,6 +427,6 @@ inline std::ostream& operator<< (
 
 #include /**/ "ace/post.h"
 
-#endif /* __RIDL_TESTC_H_IIJHJCAI_INCLUDED__ */
+#endif /* __RIDL_TESTC_H_EDCGBBEG_INCLUDED__ */
 
 // -*- END -*-

--- a/examples/axcioma/hello/receiver/hello_receiver_exec.h
+++ b/examples/axcioma/hello/receiver/hello_receiver_exec.h
@@ -56,7 +56,6 @@ namespace Hello_Receiver_Impl
     /** @name Operations from ::Hello::CCM_MyFoo */
     //@{
 
-    virtual
     std::string
     foo (
         const std::string& in_str,
@@ -66,20 +65,16 @@ namespace Hello_Receiver_Impl
     /** @name Attributes from ::Hello::CCM_MyFoo */
     //@{
 
-    virtual
     int16_t
     foo_attrib () override;
 
-    virtual
     void
     foo_attrib (
         int16_t foo_attrib) override;
 
-    virtual
     int16_t
     foo_excep () override;
 
-    virtual
     void
     foo_excep (
         int16_t foo_excep) override;

--- a/examples/const/testC.h
+++ b/examples/const/testC.h
@@ -6,8 +6,8 @@
  *        https://www.remedy.nl
  */
 
-#ifndef __RIDL_TESTC_H_DCGGAHAF_INCLUDED__
-#define __RIDL_TESTC_H_DCGGAHAF_INCLUDED__
+#ifndef __RIDL_TESTC_H_DAJFBHAG_INCLUDED__
+#define __RIDL_TESTC_H_DAJFBHAG_INCLUDED__
 
 #pragma once
 
@@ -423,6 +423,6 @@ inline std::ostream& operator<< (
 
 #include /**/ "ace/post.h"
 
-#endif /* __RIDL_TESTC_H_DCGGAHAF_INCLUDED__ */
+#endif /* __RIDL_TESTC_H_DAJFBHAG_INCLUDED__ */
 
 // -*- END -*-

--- a/examples/dds/testC.h
+++ b/examples/dds/testC.h
@@ -6,8 +6,8 @@
  *        https://www.remedy.nl
  */
 
-#ifndef __RIDL_TESTC_H_DEADIAFB_INCLUDED__
-#define __RIDL_TESTC_H_DEADIAFB_INCLUDED__
+#ifndef __RIDL_TESTC_H_JBDIDJAA_INCLUDED__
+#define __RIDL_TESTC_H_JBDIDJAA_INCLUDED__
 
 #pragma once
 
@@ -430,6 +430,6 @@ inline std::ostream& operator<< (
 
 #include /**/ "ace/post.h"
 
-#endif /* __RIDL_TESTC_H_DEADIAFB_INCLUDED__ */
+#endif /* __RIDL_TESTC_H_JBDIDJAA_INCLUDED__ */
 
 // -*- END -*-

--- a/examples/dds/testS.h
+++ b/examples/dds/testS.h
@@ -6,8 +6,8 @@
  *        https://www.remedy.nl
  */
 
-#ifndef __RIDL_TESTS_H_BDEJAHCF_INCLUDED__
-#define __RIDL_TESTS_H_BDEJAHCF_INCLUDED__
+#ifndef __RIDL_TESTS_H_GHGBFGCC_INCLUDED__
+#define __RIDL_TESTS_H_GHGBFGCC_INCLUDED__
 
 #pragma once
 
@@ -27,6 +27,6 @@ namespace TAOX11_NAMESPACE {
   } // namespace CORBA
 } // namespace TAOX11_NAMESPACE
 
-#endif /* __RIDL_TESTS_H_BDEJAHCF_INCLUDED__ */
+#endif /* __RIDL_TESTS_H_GHGBFGCC_INCLUDED__ */
 
 // -*- END -*-

--- a/examples/deployment/testC.h
+++ b/examples/deployment/testC.h
@@ -6,8 +6,8 @@
  *        https://www.remedy.nl
  */
 
-#ifndef __RIDL_TESTC_H_GFFFJFEB_INCLUDED__
-#define __RIDL_TESTC_H_GFFFJFEB_INCLUDED__
+#ifndef __RIDL_TESTC_H_FDCJBEJA_INCLUDED__
+#define __RIDL_TESTC_H_FDCJBEJA_INCLUDED__
 
 #pragma once
 
@@ -6034,6 +6034,6 @@ inline std::ostream& operator<< (
 
 #include /**/ "ace/post.h"
 
-#endif /* __RIDL_TESTC_H_GFFFJFEB_INCLUDED__ */
+#endif /* __RIDL_TESTC_H_FDCJBEJA_INCLUDED__ */
 
 // -*- END -*-

--- a/examples/enum/testC.h
+++ b/examples/enum/testC.h
@@ -6,8 +6,8 @@
  *        https://www.remedy.nl
  */
 
-#ifndef __RIDL_TESTC_H_BJHGGBFJ_INCLUDED__
-#define __RIDL_TESTC_H_BJHGGBFJ_INCLUDED__
+#ifndef __RIDL_TESTC_H_GBFEADGA_INCLUDED__
+#define __RIDL_TESTC_H_GBFEADGA_INCLUDED__
 
 #pragma once
 
@@ -134,6 +134,6 @@ inline std::ostream& operator<< (
 
 #include /**/ "ace/post.h"
 
-#endif /* __RIDL_TESTC_H_BJHGGBFJ_INCLUDED__ */
+#endif /* __RIDL_TESTC_H_GBFEADGA_INCLUDED__ */
 
 // -*- END -*-

--- a/examples/exceptions/testC.h
+++ b/examples/exceptions/testC.h
@@ -6,8 +6,8 @@
  *        https://www.remedy.nl
  */
 
-#ifndef __RIDL_TESTC_H_EBAEIFJC_INCLUDED__
-#define __RIDL_TESTC_H_EBAEIFJC_INCLUDED__
+#ifndef __RIDL_TESTC_H_HBAGHIGG_INCLUDED__
+#define __RIDL_TESTC_H_HBAGHIGG_INCLUDED__
 
 #pragma once
 
@@ -470,6 +470,6 @@ inline std::ostream& operator<< (
 
 #include /**/ "ace/post.h"
 
-#endif /* __RIDL_TESTC_H_EBAEIFJC_INCLUDED__ */
+#endif /* __RIDL_TESTC_H_HBAGHIGG_INCLUDED__ */
 
 // -*- END -*-

--- a/examples/exceptions/testS.h
+++ b/examples/exceptions/testS.h
@@ -6,8 +6,8 @@
  *        https://www.remedy.nl
  */
 
-#ifndef __RIDL_TESTS_H_CBIBDGHI_INCLUDED__
-#define __RIDL_TESTS_H_CBIBDGHI_INCLUDED__
+#ifndef __RIDL_TESTS_H_GJEHEDBJ_INCLUDED__
+#define __RIDL_TESTS_H_GJEHEDBJ_INCLUDED__
 
 #pragma once
 
@@ -127,6 +127,6 @@ namespace TAOX11_NAMESPACE {
   } // namespace CORBA
 } // namespace TAOX11_NAMESPACE
 
-#endif /* __RIDL_TESTS_H_CBIBDGHI_INCLUDED__ */
+#endif /* __RIDL_TESTS_H_GJEHEDBJ_INCLUDED__ */
 
 // -*- END -*-

--- a/examples/hello/hello.h
+++ b/examples/hello/hello.h
@@ -21,9 +21,9 @@ public:
   Hello (IDL::traits<CORBA::ORB>::ref_type orb);
 
   // = The skeleton methods
-  virtual std::string get_string () override;
+  std::string get_string () override;
 
-  virtual void shutdown () override;
+  void shutdown () override;
 
 private:
   /// Use an ORB reference to convert strings to objects and shutdown

--- a/examples/hello/testC.h
+++ b/examples/hello/testC.h
@@ -6,8 +6,8 @@
  *        https://www.remedy.nl
  */
 
-#ifndef __RIDL_TESTC_H_EDHIBEFA_INCLUDED__
-#define __RIDL_TESTC_H_EDHIBEFA_INCLUDED__
+#ifndef __RIDL_TESTC_H_EIJEEIHA_INCLUDED__
+#define __RIDL_TESTC_H_EIJEEIHA_INCLUDED__
 
 #pragma once
 
@@ -225,6 +225,6 @@ inline std::ostream& operator<< (
 
 #include /**/ "ace/post.h"
 
-#endif /* __RIDL_TESTC_H_EDHIBEFA_INCLUDED__ */
+#endif /* __RIDL_TESTC_H_EIJEEIHA_INCLUDED__ */
 
 // -*- END -*-

--- a/examples/hello/testS.h
+++ b/examples/hello/testS.h
@@ -6,8 +6,8 @@
  *        https://www.remedy.nl
  */
 
-#ifndef __RIDL_TESTS_H_GAIJHEAE_INCLUDED__
-#define __RIDL_TESTS_H_GAIJHEAE_INCLUDED__
+#ifndef __RIDL_TESTS_H_CFBBFGBA_INCLUDED__
+#define __RIDL_TESTS_H_CFBBFGBA_INCLUDED__
 
 #pragma once
 
@@ -113,6 +113,6 @@ namespace TAOX11_NAMESPACE {
   } // namespace CORBA
 } // namespace TAOX11_NAMESPACE
 
-#endif /* __RIDL_TESTS_H_GAIJHEAE_INCLUDED__ */
+#endif /* __RIDL_TESTS_H_CFBBFGBA_INCLUDED__ */
 
 // -*- END -*-

--- a/examples/hello_auto/hello.h
+++ b/examples/hello_auto/hello.h
@@ -21,7 +21,7 @@ public:
   Hello (IDL::traits<CORBA::ORB>::ref_type orb);
 
   // = The skeleton methods
-  virtual std::string get_string (void) override;
+  std::string get_string (void) override;
 
 private:
   /// Use an ORB reference to convert strings to objects and shutdown

--- a/examples/hello_auto/testC.h
+++ b/examples/hello_auto/testC.h
@@ -6,8 +6,8 @@
  *        https://www.remedy.nl
  */
 
-#ifndef __RIDL_TESTC_H_JJFHGEIH_INCLUDED__
-#define __RIDL_TESTC_H_JJFHGEIH_INCLUDED__
+#ifndef __RIDL_TESTC_H_EDCCAJAC_INCLUDED__
+#define __RIDL_TESTC_H_EDCCAJAC_INCLUDED__
 
 #pragma once
 
@@ -220,6 +220,6 @@ inline std::ostream& operator<< (
 
 #include /**/ "ace/post.h"
 
-#endif /* __RIDL_TESTC_H_JJFHGEIH_INCLUDED__ */
+#endif /* __RIDL_TESTC_H_EDCCAJAC_INCLUDED__ */
 
 // -*- END -*-

--- a/examples/hello_auto/testS.h
+++ b/examples/hello_auto/testS.h
@@ -6,8 +6,8 @@
  *        https://www.remedy.nl
  */
 
-#ifndef __RIDL_TESTS_H_DIEJBDBI_INCLUDED__
-#define __RIDL_TESTS_H_DIEJBDBI_INCLUDED__
+#ifndef __RIDL_TESTS_H_BCJIIFDC_INCLUDED__
+#define __RIDL_TESTS_H_BCJIIFDC_INCLUDED__
 
 #pragma once
 
@@ -108,6 +108,6 @@ namespace TAOX11_NAMESPACE {
   } // namespace CORBA
 } // namespace TAOX11_NAMESPACE
 
-#endif /* __RIDL_TESTS_H_DIEJBDBI_INCLUDED__ */
+#endif /* __RIDL_TESTS_H_BCJIIFDC_INCLUDED__ */
 
 // -*- END -*-

--- a/examples/hello_tie/hello.h
+++ b/examples/hello_tie/hello.h
@@ -20,9 +20,9 @@ public:
   Hello (IDL::traits<CORBA::ORB>::ref_type orb);
 
   // = The skeleton methods
-  virtual std::string get_string () override;
+  std::string get_string () override;
 
-  virtual void shutdown () override;
+  void shutdown () override;
 
 private:
   /// Use an ORB reference to convert strings to objects and shutdown

--- a/examples/local/foo.h
+++ b/examples/local/foo.h
@@ -12,5 +12,5 @@
 class Foo_impl : public virtual IDL::traits<Test::Foo>::base_type
 {
 public:
-  virtual void do_something (void) override;
+  void do_something (void) override;
 };

--- a/examples/local/testC.h
+++ b/examples/local/testC.h
@@ -6,8 +6,8 @@
  *        https://www.remedy.nl
  */
 
-#ifndef __RIDL_TESTC_H_EBIGDBCF_INCLUDED__
-#define __RIDL_TESTC_H_EBIGDBCF_INCLUDED__
+#ifndef __RIDL_TESTC_H_CJHBCIAE_INCLUDED__
+#define __RIDL_TESTC_H_CJHBCIAE_INCLUDED__
 
 #pragma once
 
@@ -120,7 +120,7 @@ namespace Test
   protected:
     typedef std::shared_ptr<Foo> _shared_ptr_type;
 
-#if defined (_MSC_VER) && (_MSC_VER < 1920)
+#if defined (_MSC_VER) && (_MSC_VER < 1930)
     /// Default constructor
     Foo () {};
 #else
@@ -231,7 +231,7 @@ namespace Test
   protected:
     typedef std::shared_ptr<Bar> _shared_ptr_type;
 
-#if defined (_MSC_VER) && (_MSC_VER < 1920)
+#if defined (_MSC_VER) && (_MSC_VER < 1930)
     /// Default constructor
     Bar () {};
 #else
@@ -389,6 +389,6 @@ inline std::ostream& operator<< (
 
 #include /**/ "ace/post.h"
 
-#endif /* __RIDL_TESTC_H_EBIGDBCF_INCLUDED__ */
+#endif /* __RIDL_TESTC_H_CJHBCIAE_INCLUDED__ */
 
 // -*- END -*-

--- a/examples/local/testS.h
+++ b/examples/local/testS.h
@@ -6,8 +6,8 @@
  *        https://www.remedy.nl
  */
 
-#ifndef __RIDL_TESTS_H_FGBHBAAD_INCLUDED__
-#define __RIDL_TESTS_H_FGBHBAAD_INCLUDED__
+#ifndef __RIDL_TESTS_H_DDAIDBGF_INCLUDED__
+#define __RIDL_TESTS_H_DDAIDBGF_INCLUDED__
 
 #pragma once
 
@@ -33,6 +33,6 @@ namespace TAOX11_NAMESPACE {
   } // namespace CORBA
 } // namespace TAOX11_NAMESPACE
 
-#endif /* __RIDL_TESTS_H_FGBHBAAD_INCLUDED__ */
+#endif /* __RIDL_TESTS_H_DDAIDBGF_INCLUDED__ */
 
 // -*- END -*-

--- a/examples/objrefarg/testC.h
+++ b/examples/objrefarg/testC.h
@@ -6,8 +6,8 @@
  *        https://www.remedy.nl
  */
 
-#ifndef __RIDL_TESTC_H_HAHGEBAH_INCLUDED__
-#define __RIDL_TESTC_H_HAHGEBAH_INCLUDED__
+#ifndef __RIDL_TESTC_H_JDFJFHDE_INCLUDED__
+#define __RIDL_TESTC_H_JDFJFHDE_INCLUDED__
 
 #pragma once
 
@@ -410,6 +410,6 @@ inline std::ostream& operator<< (
 
 #include /**/ "ace/post.h"
 
-#endif /* __RIDL_TESTC_H_HAHGEBAH_INCLUDED__ */
+#endif /* __RIDL_TESTC_H_JDFJFHDE_INCLUDED__ */
 
 // -*- END -*-

--- a/examples/radartrack/testC.h
+++ b/examples/radartrack/testC.h
@@ -6,8 +6,8 @@
  *        https://www.remedy.nl
  */
 
-#ifndef __RIDL_TESTC_H_GCJCGJAF_INCLUDED__
-#define __RIDL_TESTC_H_GCJCGJAF_INCLUDED__
+#ifndef __RIDL_TESTC_H_FGFIEAEI_INCLUDED__
+#define __RIDL_TESTC_H_FGFIEAEI_INCLUDED__
 
 #pragma once
 
@@ -293,6 +293,6 @@ operator<< (
 
 #include /**/ "ace/post.h"
 
-#endif /* __RIDL_TESTC_H_GCJCGJAF_INCLUDED__ */
+#endif /* __RIDL_TESTC_H_FGFIEAEI_INCLUDED__ */
 
 // -*- END -*-

--- a/examples/sequence/testC.h
+++ b/examples/sequence/testC.h
@@ -6,8 +6,8 @@
  *        https://www.remedy.nl
  */
 
-#ifndef __RIDL_TESTC_H_EAEFCGBH_INCLUDED__
-#define __RIDL_TESTC_H_EAEFCGBH_INCLUDED__
+#ifndef __RIDL_TESTC_H_FGBCJJJE_INCLUDED__
+#define __RIDL_TESTC_H_FGBCJJJE_INCLUDED__
 
 #pragma once
 
@@ -774,6 +774,6 @@ inline std::ostream& operator<< (
 
 #include /**/ "ace/post.h"
 
-#endif /* __RIDL_TESTC_H_EAEFCGBH_INCLUDED__ */
+#endif /* __RIDL_TESTC_H_FGBCJJJE_INCLUDED__ */
 
 // -*- END -*-

--- a/examples/struct/testC.h
+++ b/examples/struct/testC.h
@@ -6,8 +6,8 @@
  *        https://www.remedy.nl
  */
 
-#ifndef __RIDL_TESTC_H_GAHEFFID_INCLUDED__
-#define __RIDL_TESTC_H_GAHEFFID_INCLUDED__
+#ifndef __RIDL_TESTC_H_GICHCJCA_INCLUDED__
+#define __RIDL_TESTC_H_GICHCJCA_INCLUDED__
 
 #pragma once
 
@@ -745,6 +745,6 @@ inline std::ostream& operator<< (
 
 #include /**/ "ace/post.h"
 
-#endif /* __RIDL_TESTC_H_GAHEFFID_INCLUDED__ */
+#endif /* __RIDL_TESTC_H_GICHCJCA_INCLUDED__ */
 
 // -*- END -*-

--- a/examples/union/testC.h
+++ b/examples/union/testC.h
@@ -6,8 +6,8 @@
  *        https://www.remedy.nl
  */
 
-#ifndef __RIDL_TESTC_H_FFHEJHEJ_INCLUDED__
-#define __RIDL_TESTC_H_FFHEJHEJ_INCLUDED__
+#ifndef __RIDL_TESTC_H_IJDCIEBA_INCLUDED__
+#define __RIDL_TESTC_H_IJDCIEBA_INCLUDED__
 
 #pragma once
 
@@ -2515,6 +2515,6 @@ inline std::ostream& operator<< (
 
 #include /**/ "ace/post.h"
 
-#endif /* __RIDL_TESTC_H_FFHEJHEJ_INCLUDED__ */
+#endif /* __RIDL_TESTC_H_IJDCIEBA_INCLUDED__ */
 
 // -*- END -*-

--- a/examples/valuetype/testC.h
+++ b/examples/valuetype/testC.h
@@ -6,8 +6,8 @@
  *        https://www.remedy.nl
  */
 
-#ifndef __RIDL_TESTC_H_BCABGIFI_INCLUDED__
-#define __RIDL_TESTC_H_BCABGIFI_INCLUDED__
+#ifndef __RIDL_TESTC_H_HDCGHFCH_INCLUDED__
+#define __RIDL_TESTC_H_HDCGHFCH_INCLUDED__
 
 #pragma once
 
@@ -2332,6 +2332,6 @@ operator<< (
 
 #include /**/ "ace/post.h"
 
-#endif /* __RIDL_TESTC_H_BCABGIFI_INCLUDED__ */
+#endif /* __RIDL_TESTC_H_HDCGHFCH_INCLUDED__ */
 
 // -*- END -*-

--- a/examples/valuetype/testS.h
+++ b/examples/valuetype/testS.h
@@ -6,8 +6,8 @@
  *        https://www.remedy.nl
  */
 
-#ifndef __RIDL_TESTS_H_BGJEBHEH_INCLUDED__
-#define __RIDL_TESTS_H_BGJEBHEH_INCLUDED__
+#ifndef __RIDL_TESTS_H_BJADEEFA_INCLUDED__
+#define __RIDL_TESTS_H_BJADEEFA_INCLUDED__
 
 #pragma once
 
@@ -302,6 +302,6 @@ namespace TAOX11_NAMESPACE {
   } // namespace CORBA
 } // namespace TAOX11_NAMESPACE
 
-#endif /* __RIDL_TESTS_H_BGJEBHEH_INCLUDED__ */
+#endif /* __RIDL_TESTS_H_BJADEEFA_INCLUDED__ */
 
 // -*- END -*-


### PR DESCRIPTION
    * examples/array/testC.h:
    * examples/axcioma/hello/receiver/hello_receiver_exec.h:
    * examples/const/testC.h:
    * examples/dds/testC.h:
    * examples/dds/testS.h:
    * examples/deployment/testC.h:
    * examples/enum/testC.h:
    * examples/exceptions/testC.h:
    * examples/exceptions/testS.h:
    * examples/hello/hello.h:
    * examples/hello/testC.h:
    * examples/hello/testS.h:
    * examples/hello_auto/hello.h:
    * examples/hello_auto/testC.h:
    * examples/hello_auto/testS.h:
    * examples/hello_tie/hello.h:
    * examples/local/foo.h:
    * examples/local/testC.h:
    * examples/local/testS.h:
    * examples/objrefarg/testC.h:
    * examples/radartrack/testC.h:
    * examples/sequence/testC.h:
    * examples/struct/testC.h:
    * examples/union/testC.h:
    * examples/valuetype/testC.h:
    * examples/valuetype/testS.h: