### PR TITLE
Regenerated with latest ridlc

### DIFF
--- a/examples/array/testC.h
+++ b/examples/array/testC.h
@@ -6,8 +6,8 @@
  *        https://www.remedy.nl
  */
 
-#ifndef __RIDL_TESTC_H_JIBFBGBG_INCLUDED__
-#define __RIDL_TESTC_H_JIBFBGBG_INCLUDED__
+#ifndef __RIDL_TESTC_H_JCDFEBFB_INCLUDED__
+#define __RIDL_TESTC_H_JCDFEBFB_INCLUDED__
 
 #pragma once
 
@@ -390,6 +390,6 @@ inline std::ostream& operator<< (std::ostream& strm, IDL::traits<::Test::Foo>::r
 
 #include /**/ "tao/x11/base/post.h"
 
-#endif /* __RIDL_TESTC_H_JIBFBGBG_INCLUDED__ */
+#endif /* __RIDL_TESTC_H_JCDFEBFB_INCLUDED__ */
 
 // -*- END -*-

--- a/examples/const/testC.h
+++ b/examples/const/testC.h
@@ -6,8 +6,8 @@
  *        https://www.remedy.nl
  */
 
-#ifndef __RIDL_TESTC_H_HGEBJAEI_INCLUDED__
-#define __RIDL_TESTC_H_HGEBJAEI_INCLUDED__
+#ifndef __RIDL_TESTC_H_HBAEBBJE_INCLUDED__
+#define __RIDL_TESTC_H_HBAEBBJE_INCLUDED__
 
 #pragma once
 
@@ -390,6 +390,6 @@ inline std::ostream& operator<< (std::ostream& strm, IDL::traits<::A>::ref_type 
 
 #include /**/ "tao/x11/base/post.h"
 
-#endif /* __RIDL_TESTC_H_HGEBJAEI_INCLUDED__ */
+#endif /* __RIDL_TESTC_H_HBAEBBJE_INCLUDED__ */
 
 // -*- END -*-

--- a/examples/dds/testC.h
+++ b/examples/dds/testC.h
@@ -6,8 +6,8 @@
  *        https://www.remedy.nl
  */
 
-#ifndef __RIDL_TESTC_H_FFCBIEFF_INCLUDED__
-#define __RIDL_TESTC_H_FFCBIEFF_INCLUDED__
+#ifndef __RIDL_TESTC_H_HDACHHBC_INCLUDED__
+#define __RIDL_TESTC_H_HDACHHBC_INCLUDED__
 
 #pragma once
 
@@ -377,6 +377,6 @@ inline std::ostream& operator<< (std::ostream& strm, const ::ShapeTypeSeq& _v)
 
 #include /**/ "tao/x11/base/post.h"
 
-#endif /* __RIDL_TESTC_H_FFCBIEFF_INCLUDED__ */
+#endif /* __RIDL_TESTC_H_HDACHHBC_INCLUDED__ */
 
 // -*- END -*-

--- a/examples/dds/testS.h
+++ b/examples/dds/testS.h
@@ -6,8 +6,8 @@
  *        https://www.remedy.nl
  */
 
-#ifndef __RIDL_TESTS_H_IIJHJEDA_INCLUDED__
-#define __RIDL_TESTS_H_IIJHJEDA_INCLUDED__
+#ifndef __RIDL_TESTS_H_FGHGJACD_INCLUDED__
+#define __RIDL_TESTS_H_FGHGJACD_INCLUDED__
 
 #pragma once
 
@@ -19,6 +19,6 @@
 #error This file was generated with another RIDL C++11 backend version (2.6.0). Please re-generate.
 #endif
 
-#endif /* __RIDL_TESTS_H_IIJHJEDA_INCLUDED__ */
+#endif /* __RIDL_TESTS_H_FGHGJACD_INCLUDED__ */
 
 // -*- END -*-

--- a/examples/deployment/testC.h
+++ b/examples/deployment/testC.h
@@ -6,8 +6,8 @@
  *        https://www.remedy.nl
  */
 
-#ifndef __RIDL_TESTC_H_IEGGJAGE_INCLUDED__
-#define __RIDL_TESTC_H_IEGGJAGE_INCLUDED__
+#ifndef __RIDL_TESTC_H_DHDFHCCH_INCLUDED__
+#define __RIDL_TESTC_H_DHDFHCCH_INCLUDED__
 
 #pragma once
 
@@ -5433,6 +5433,6 @@ inline std::ostream& operator<< (std::ostream& strm, const ::Deployment::Capabil
 
 #include /**/ "tao/x11/base/post.h"
 
-#endif /* __RIDL_TESTC_H_IEGGJAGE_INCLUDED__ */
+#endif /* __RIDL_TESTC_H_DHDFHCCH_INCLUDED__ */
 
 // -*- END -*-

--- a/examples/enum/testC.h
+++ b/examples/enum/testC.h
@@ -6,8 +6,8 @@
  *        https://www.remedy.nl
  */
 
-#ifndef __RIDL_TESTC_H_FIEBCHBH_INCLUDED__
-#define __RIDL_TESTC_H_FIEBCHBH_INCLUDED__
+#ifndef __RIDL_TESTC_H_GGHJECFG_INCLUDED__
+#define __RIDL_TESTC_H_GGHJECFG_INCLUDED__
 
 #pragma once
 
@@ -120,6 +120,6 @@ inline std::ostream& operator<< (std::ostream& strm, ::Test::EEnum _v)
 
 #include /**/ "tao/x11/base/post.h"
 
-#endif /* __RIDL_TESTC_H_FIEBCHBH_INCLUDED__ */
+#endif /* __RIDL_TESTC_H_GGHJECFG_INCLUDED__ */
 
 // -*- END -*-

--- a/examples/exceptions/testC.h
+++ b/examples/exceptions/testC.h
@@ -6,8 +6,8 @@
  *        https://www.remedy.nl
  */
 
-#ifndef __RIDL_TESTC_H_GIAGHFGJ_INCLUDED__
-#define __RIDL_TESTC_H_GIAGHFGJ_INCLUDED__
+#ifndef __RIDL_TESTC_H_HAGFICAH_INCLUDED__
+#define __RIDL_TESTC_H_HAGFICAH_INCLUDED__
 
 #pragma once
 
@@ -424,6 +424,6 @@ inline std::ostream& operator<< (std::ostream& strm, IDL::traits<::Test::Foo>::r
 
 #include /**/ "tao/x11/base/post.h"
 
-#endif /* __RIDL_TESTC_H_GIAGHFGJ_INCLUDED__ */
+#endif /* __RIDL_TESTC_H_HAGFICAH_INCLUDED__ */
 
 // -*- END -*-

--- a/examples/exceptions/testS.h
+++ b/examples/exceptions/testS.h
@@ -6,8 +6,8 @@
  *        https://www.remedy.nl
  */
 
-#ifndef __RIDL_TESTS_H_JHCBFEAJ_INCLUDED__
-#define __RIDL_TESTS_H_JHCBFEAJ_INCLUDED__
+#ifndef __RIDL_TESTS_H_IJDGEFCE_INCLUDED__
+#define __RIDL_TESTS_H_IJDGEFCE_INCLUDED__
 
 #pragma once
 
@@ -121,6 +121,6 @@ namespace TAOX11_NAMESPACE::CORBA {
   };
 } // namespace TAOX11_NAMESPACE::CORBA
 
-#endif /* __RIDL_TESTS_H_JHCBFEAJ_INCLUDED__ */
+#endif /* __RIDL_TESTS_H_IJDGEFCE_INCLUDED__ */
 
 // -*- END -*-

--- a/examples/hello/testC.h
+++ b/examples/hello/testC.h
@@ -6,8 +6,8 @@
  *        https://www.remedy.nl
  */
 
-#ifndef __RIDL_TESTC_H_IDDBEGAA_INCLUDED__
-#define __RIDL_TESTC_H_IDDBEGAA_INCLUDED__
+#ifndef __RIDL_TESTC_H_DCDIJHEH_INCLUDED__
+#define __RIDL_TESTC_H_DCDIJHEH_INCLUDED__
 
 #pragma once
 
@@ -203,6 +203,6 @@ inline std::ostream& operator<< (std::ostream& strm, IDL::traits<::Test::Hello>:
 
 #include /**/ "tao/x11/base/post.h"
 
-#endif /* __RIDL_TESTC_H_IDDBEGAA_INCLUDED__ */
+#endif /* __RIDL_TESTC_H_DCDIJHEH_INCLUDED__ */
 
 // -*- END -*-

--- a/examples/hello/testS.h
+++ b/examples/hello/testS.h
@@ -6,8 +6,8 @@
  *        https://www.remedy.nl
  */
 
-#ifndef __RIDL_TESTS_H_FIJAAHBI_INCLUDED__
-#define __RIDL_TESTS_H_FIJAAHBI_INCLUDED__
+#ifndef __RIDL_TESTS_H_HCIDHDJD_INCLUDED__
+#define __RIDL_TESTS_H_HCIDHDJD_INCLUDED__
 
 #pragma once
 
@@ -107,6 +107,6 @@ namespace TAOX11_NAMESPACE::CORBA {
   };
 } // namespace TAOX11_NAMESPACE::CORBA
 
-#endif /* __RIDL_TESTS_H_FIJAAHBI_INCLUDED__ */
+#endif /* __RIDL_TESTS_H_HCIDHDJD_INCLUDED__ */
 
 // -*- END -*-

--- a/examples/hello_auto/testC.h
+++ b/examples/hello_auto/testC.h
@@ -6,8 +6,8 @@
  *        https://www.remedy.nl
  */
 
-#ifndef __RIDL_TESTC_H_EHAAFIFG_INCLUDED__
-#define __RIDL_TESTC_H_EHAAFIFG_INCLUDED__
+#ifndef __RIDL_TESTC_H_BDHEEEJA_INCLUDED__
+#define __RIDL_TESTC_H_BDHEEEJA_INCLUDED__
 
 #pragma once
 
@@ -198,6 +198,6 @@ inline std::ostream& operator<< (std::ostream& strm, IDL::traits<::Test::Hello>:
 
 #include /**/ "tao/x11/base/post.h"
 
-#endif /* __RIDL_TESTC_H_EHAAFIFG_INCLUDED__ */
+#endif /* __RIDL_TESTC_H_BDHEEEJA_INCLUDED__ */
 
 // -*- END -*-

--- a/examples/hello_auto/testS.h
+++ b/examples/hello_auto/testS.h
@@ -6,8 +6,8 @@
  *        https://www.remedy.nl
  */
 
-#ifndef __RIDL_TESTS_H_CEJCFGFI_INCLUDED__
-#define __RIDL_TESTS_H_CEJCFGFI_INCLUDED__
+#ifndef __RIDL_TESTS_H_DAJFHIGJ_INCLUDED__
+#define __RIDL_TESTS_H_DAJFHIGJ_INCLUDED__
 
 #pragma once
 
@@ -102,6 +102,6 @@ namespace TAOX11_NAMESPACE::CORBA {
   };
 } // namespace TAOX11_NAMESPACE::CORBA
 
-#endif /* __RIDL_TESTS_H_CEJCFGFI_INCLUDED__ */
+#endif /* __RIDL_TESTS_H_DAJFHIGJ_INCLUDED__ */
 
 // -*- END -*-

--- a/examples/idl4/bitmask/testC.h
+++ b/examples/idl4/bitmask/testC.h
@@ -6,8 +6,8 @@
  *        https://www.remedy.nl
  */
 
-#ifndef __RIDL_TESTC_H_DDFEGCEI_INCLUDED__
-#define __RIDL_TESTC_H_DDFEGCEI_INCLUDED__
+#ifndef __RIDL_TESTC_H_FAEECHHJ_INCLUDED__
+#define __RIDL_TESTC_H_FAEECHHJ_INCLUDED__
 
 #pragma once
 
@@ -139,6 +139,6 @@ inline std::ostream& operator<< (std::ostream& strm, const ::MyBitMask& _v)
 
 #include /**/ "tao/x11/base/post.h"
 
-#endif /* __RIDL_TESTC_H_DDFEGCEI_INCLUDED__ */
+#endif /* __RIDL_TESTC_H_FAEECHHJ_INCLUDED__ */
 
 // -*- END -*-

--- a/examples/idl4/bitset/testC.h
+++ b/examples/idl4/bitset/testC.h
@@ -6,8 +6,8 @@
  *        https://www.remedy.nl
  */
 
-#ifndef __RIDL_TESTC_H_GIAFICCJ_INCLUDED__
-#define __RIDL_TESTC_H_GIAFICCJ_INCLUDED__
+#ifndef __RIDL_TESTC_H_DAGCCCGD_INCLUDED__
+#define __RIDL_TESTC_H_DAGCCCGD_INCLUDED__
 
 #pragma once
 
@@ -290,6 +290,6 @@ inline std::ostream& operator<< (std::ostream& strm, const ::MyBitset2& _v)
 
 #include /**/ "tao/x11/base/post.h"
 
-#endif /* __RIDL_TESTC_H_GIAFICCJ_INCLUDED__ */
+#endif /* __RIDL_TESTC_H_DAGCCCGD_INCLUDED__ */
 
 // -*- END -*-

--- a/examples/idl4/map/testC.h
+++ b/examples/idl4/map/testC.h
@@ -6,8 +6,8 @@
  *        https://www.remedy.nl
  */
 
-#ifndef __RIDL_TESTC_H_EHDHJJDI_INCLUDED__
-#define __RIDL_TESTC_H_EHDHJJDI_INCLUDED__
+#ifndef __RIDL_TESTC_H_EBHACCHA_INCLUDED__
+#define __RIDL_TESTC_H_EBHACCHA_INCLUDED__
 
 #pragma once
 
@@ -113,6 +113,6 @@ inline std::ostream& operator<< (std::ostream& strm, const ::Test::StringLongMap
 
 #include /**/ "tao/x11/base/post.h"
 
-#endif /* __RIDL_TESTC_H_EHDHJJDI_INCLUDED__ */
+#endif /* __RIDL_TESTC_H_EBHACCHA_INCLUDED__ */
 
 // -*- END -*-

--- a/examples/idl4/struct_inheritance/testC.h
+++ b/examples/idl4/struct_inheritance/testC.h
@@ -6,8 +6,8 @@
  *        https://www.remedy.nl
  */
 
-#ifndef __RIDL_TESTC_H_IJHAABHA_INCLUDED__
-#define __RIDL_TESTC_H_IJHAABHA_INCLUDED__
+#ifndef __RIDL_TESTC_H_IFDEAAAB_INCLUDED__
+#define __RIDL_TESTC_H_IFDEAAAB_INCLUDED__
 
 #pragma once
 
@@ -265,6 +265,6 @@ inline std::ostream& operator<< (std::ostream& strm, const ::Point3D& _v)
 
 #include /**/ "tao/x11/base/post.h"
 
-#endif /* __RIDL_TESTC_H_IJHAABHA_INCLUDED__ */
+#endif /* __RIDL_TESTC_H_IFDEAAAB_INCLUDED__ */
 
 // -*- END -*-

--- a/examples/local/testC.h
+++ b/examples/local/testC.h
@@ -6,8 +6,8 @@
  *        https://www.remedy.nl
  */
 
-#ifndef __RIDL_TESTC_H_JDAEHEEH_INCLUDED__
-#define __RIDL_TESTC_H_JDAEHEEH_INCLUDED__
+#ifndef __RIDL_TESTC_H_GEGBHBEC_INCLUDED__
+#define __RIDL_TESTC_H_GEGBHBEC_INCLUDED__
 
 #pragma once
 
@@ -119,13 +119,8 @@ namespace Test
   protected:
     using _shared_ptr_type = std::shared_ptr<Foo>;
 
-#if defined (_MSC_VER) && (_MSC_VER < 1930)
-    /// Default constructor
-    Foo () {};
-#else
     /// Default constructor
     Foo () = default;
-#endif /* _MSC_VER < 1930 */
     /// Destructor
     ~Foo () override = default;
 
@@ -229,13 +224,8 @@ namespace Test
   protected:
     using _shared_ptr_type = std::shared_ptr<Bar>;
 
-#if defined (_MSC_VER) && (_MSC_VER < 1930)
-    /// Default constructor
-    Bar () {};
-#else
     /// Default constructor
     Bar () = default;
-#endif /* _MSC_VER < 1930 */
     /// Destructor
     ~Bar () override = default;
 
@@ -353,6 +343,6 @@ inline std::ostream& operator<< (std::ostream& strm, IDL::traits<::Test::Bar>::r
 
 #include /**/ "tao/x11/base/post.h"
 
-#endif /* __RIDL_TESTC_H_JDAEHEEH_INCLUDED__ */
+#endif /* __RIDL_TESTC_H_GEGBHBEC_INCLUDED__ */
 
 // -*- END -*-

--- a/examples/local/testS.h
+++ b/examples/local/testS.h
@@ -6,8 +6,8 @@
  *        https://www.remedy.nl
  */
 
-#ifndef __RIDL_TESTS_H_CIFEGECA_INCLUDED__
-#define __RIDL_TESTS_H_CIFEGECA_INCLUDED__
+#ifndef __RIDL_TESTS_H_GCEEIEIF_INCLUDED__
+#define __RIDL_TESTS_H_GCEEIEIF_INCLUDED__
 
 #pragma once
 
@@ -27,6 +27,6 @@ namespace Test
 } // namespace Test
 
 
-#endif /* __RIDL_TESTS_H_CIFEGECA_INCLUDED__ */
+#endif /* __RIDL_TESTS_H_GCEEIEIF_INCLUDED__ */
 
 // -*- END -*-

--- a/examples/objrefarg/testC.h
+++ b/examples/objrefarg/testC.h
@@ -6,8 +6,8 @@
  *        https://www.remedy.nl
  */
 
-#ifndef __RIDL_TESTC_H_FAJHEBIE_INCLUDED__
-#define __RIDL_TESTC_H_FAJHEBIE_INCLUDED__
+#ifndef __RIDL_TESTC_H_BIFBHEAJ_INCLUDED__
+#define __RIDL_TESTC_H_BIFBHEAJ_INCLUDED__
 
 #pragma once
 
@@ -368,6 +368,6 @@ inline std::ostream& operator<< (std::ostream& strm, IDL::traits<::Test::Hello>:
 
 #include /**/ "tao/x11/base/post.h"
 
-#endif /* __RIDL_TESTC_H_FAJHEBIE_INCLUDED__ */
+#endif /* __RIDL_TESTC_H_BIFBHEAJ_INCLUDED__ */
 
 // -*- END -*-

--- a/examples/radartrack/testC.h
+++ b/examples/radartrack/testC.h
@@ -6,8 +6,8 @@
  *        https://www.remedy.nl
  */
 
-#ifndef __RIDL_TESTC_H_EDGGEHDA_INCLUDED__
-#define __RIDL_TESTC_H_EDGGEHDA_INCLUDED__
+#ifndef __RIDL_TESTC_H_EHHCCFHD_INCLUDED__
+#define __RIDL_TESTC_H_EHHCCFHD_INCLUDED__
 
 #pragma once
 
@@ -260,6 +260,6 @@ inline std::ostream& operator<< (std::ostream& strm, const ::RadarTrack& _v)
 
 #include /**/ "tao/x11/base/post.h"
 
-#endif /* __RIDL_TESTC_H_EDGGEHDA_INCLUDED__ */
+#endif /* __RIDL_TESTC_H_EHHCCFHD_INCLUDED__ */
 
 // -*- END -*-

--- a/examples/sequence/testC.h
+++ b/examples/sequence/testC.h
@@ -6,8 +6,8 @@
  *        https://www.remedy.nl
  */
 
-#ifndef __RIDL_TESTC_H_BIHHCDBG_INCLUDED__
-#define __RIDL_TESTC_H_BIHHCDBG_INCLUDED__
+#ifndef __RIDL_TESTC_H_JDACGBCJ_INCLUDED__
+#define __RIDL_TESTC_H_JDACGBCJ_INCLUDED__
 
 #pragma once
 
@@ -712,6 +712,6 @@ inline std::ostream& operator<< (std::ostream& strm, IDL::traits<::Test::Foo>::r
 
 #include /**/ "tao/x11/base/post.h"
 
-#endif /* __RIDL_TESTC_H_BIHHCDBG_INCLUDED__ */
+#endif /* __RIDL_TESTC_H_JDACGBCJ_INCLUDED__ */
 
 // -*- END -*-

--- a/examples/struct/testC.h
+++ b/examples/struct/testC.h
@@ -6,8 +6,8 @@
  *        https://www.remedy.nl
  */
 
-#ifndef __RIDL_TESTC_H_DDIFFCHD_INCLUDED__
-#define __RIDL_TESTC_H_DDIFFCHD_INCLUDED__
+#ifndef __RIDL_TESTC_H_DJAGJCFC_INCLUDED__
+#define __RIDL_TESTC_H_DJAGJCFC_INCLUDED__
 
 #pragma once
 
@@ -667,6 +667,6 @@ inline std::ostream& operator<< (std::ostream& strm, IDL::traits<::Test::Foo>::r
 
 #include /**/ "tao/x11/base/post.h"
 
-#endif /* __RIDL_TESTC_H_DDIFFCHD_INCLUDED__ */
+#endif /* __RIDL_TESTC_H_DJAGJCFC_INCLUDED__ */
 
 // -*- END -*-

--- a/examples/union/testC.h
+++ b/examples/union/testC.h
@@ -6,8 +6,8 @@
  *        https://www.remedy.nl
  */
 
-#ifndef __RIDL_TESTC_H_HFFCAJDB_INCLUDED__
-#define __RIDL_TESTC_H_HFFCAJDB_INCLUDED__
+#ifndef __RIDL_TESTC_H_IEHEEIJE_INCLUDED__
+#define __RIDL_TESTC_H_IEHEEIJE_INCLUDED__
 
 #pragma once
 
@@ -301,17 +301,9 @@ namespace Test
     DataType disc_ {::Test::DataType::dtEmpty};
     union u_type_
     {
-#if defined (_MSC_VER) && (_MSC_VER < 1930)
-      u_type_ ();
-#else
       u_type_ () = default;
-#endif
       ~u_type_ ();
-#if defined (_MSC_VER) && (_MSC_VER < 1930)
-      int32_t longData_;
-#else
       int32_t longData_ {};
-#endif
       int16_t shortData_;
       std::string stringData_;
       ::Test::Point pointData_;
@@ -511,20 +503,12 @@ namespace Test
     int32_t disc_ {(-2147483647-1)};
     union u_type_
     {
-#if defined (_MSC_VER) && (_MSC_VER < 1930)
-      u_type_ ();
-#else
       u_type_ () = default;
-#endif
       ~u_type_ ();
       int32_t x_;
       std::string z_;
       ::Test::S w_;
-#if defined (_MSC_VER) && (_MSC_VER < 1930)
-      IDL::traits<::Test::A>::ref_type obj_;
-#else
       IDL::traits<::Test::A>::ref_type obj_ {};
-#endif
     } u_ {};
   }; // class U
 
@@ -1265,13 +1249,6 @@ inline void ::Test::Track::swap (::Test::Track& s)
   std::swap (this->p_, s.p_);
 }
 // generated from c++11/templates/cli/inl/union_inl
-#if defined (_MSC_VER) && (_MSC_VER < 1930)
-inline Test::Data::u_type_::u_type_ ()
-  : longData_{}
-{
-}
-#endif
-
 inline Test::Data::u_type_::~u_type_ ()
 {
 }
@@ -1887,13 +1864,6 @@ inline void ::Test::S::swap (::Test::S& s)
   std::swap (this->len_, s.len_);
 }
 // generated from c++11/templates/cli/inl/union_inl
-#if defined (_MSC_VER) && (_MSC_VER < 1930)
-inline Test::U::u_type_::u_type_ ()
-  : obj_{}
-{
-}
-#endif
-
 inline Test::U::u_type_::~u_type_ ()
 {
 }
@@ -2403,6 +2373,6 @@ inline std::ostream& operator<< (std::ostream& strm, IDL::traits<::Test::A>::ref
 
 #include /**/ "tao/x11/base/post.h"
 
-#endif /* __RIDL_TESTC_H_HFFCAJDB_INCLUDED__ */
+#endif /* __RIDL_TESTC_H_IEHEEIJE_INCLUDED__ */
 
 // -*- END -*-

--- a/examples/valuetype/testC.h
+++ b/examples/valuetype/testC.h
@@ -6,8 +6,8 @@
  *        https://www.remedy.nl
  */
 
-#ifndef __RIDL_TESTC_H_BFCDGHBF_INCLUDED__
-#define __RIDL_TESTC_H_BFCDGHBF_INCLUDED__
+#ifndef __RIDL_TESTC_H_CCAGEBDI_INCLUDED__
+#define __RIDL_TESTC_H_CCAGEBDI_INCLUDED__
 
 #pragma once
 
@@ -200,11 +200,7 @@ namespace obv
     : public virtual ::Example
   {
   protected:
-#if defined (_MSC_VER) && (_MSC_VER < 1920)
-    Example () {}
-#else
     Example () = default;
-#endif /* _MSC_VER < 1920 */
     ~Example () override = default;
     Example (const Example&) = default;
     Example (Example&&) = default;
@@ -583,11 +579,7 @@ namespace obv
     : public virtual ::Val
   {
   protected:
-#if defined (_MSC_VER) && (_MSC_VER < 1920)
-    Val () {}
-#else
     Val () = default;
-#endif /* _MSC_VER < 1920 */
     ~Val () override = default;
     Val (const Val&) = default;
     Val (Val&&) = default;
@@ -1288,11 +1280,7 @@ namespace obv
     : public virtual ::B
   {
   protected:
-#if defined (_MSC_VER) && (_MSC_VER < 1920)
-    B () {}
-#else
     B () = default;
-#endif /* _MSC_VER < 1920 */
     ~B () override = default;
     B (const B&) = default;
     B (B&&) = default;
@@ -1485,11 +1473,7 @@ namespace obv
     : public virtual ::V
   {
   protected:
-#if defined (_MSC_VER) && (_MSC_VER < 1920)
-    V () {}
-#else
     V () = default;
-#endif /* _MSC_VER < 1920 */
     ~V () override = default;
     V (const V&) = default;
     V (V&&) = default;
@@ -2209,6 +2193,6 @@ operator<< (
 
 #include /**/ "tao/x11/base/post.h"
 
-#endif /* __RIDL_TESTC_H_BFCDGHBF_INCLUDED__ */
+#endif /* __RIDL_TESTC_H_CCAGEBDI_INCLUDED__ */
 
 // -*- END -*-

--- a/examples/valuetype/testS.h
+++ b/examples/valuetype/testS.h
@@ -6,8 +6,8 @@
  *        https://www.remedy.nl
  */
 
-#ifndef __RIDL_TESTS_H_BDDDJAJG_INCLUDED__
-#define __RIDL_TESTS_H_BDDDJAJG_INCLUDED__
+#ifndef __RIDL_TESTS_H_HIBGGECJ_INCLUDED__
+#define __RIDL_TESTS_H_HIBGGECJ_INCLUDED__
 
 #pragma once
 
@@ -299,6 +299,6 @@ namespace TAOX11_NAMESPACE::CORBA {
   };
 } // namespace TAOX11_NAMESPACE::CORBA
 
-#endif /* __RIDL_TESTS_H_BDDDJAJG_INCLUDED__ */
+#endif /* __RIDL_TESTS_H_HIBGGECJ_INCLUDED__ */
 
 // -*- END -*-


### PR DESCRIPTION
    * examples/array/testC.h:
    * examples/const/testC.h:
    * examples/dds/testC.h:
    * examples/dds/testS.h:
    * examples/deployment/testC.h:
    * examples/enum/testC.h:
    * examples/exceptions/testC.h:
    * examples/exceptions/testS.h:
    * examples/hello/testC.h:
    * examples/hello/testS.h:
    * examples/hello_auto/testC.h:
    * examples/hello_auto/testS.h:
    * examples/idl4/bitmask/testC.h:
    * examples/idl4/bitset/testC.h:
    * examples/idl4/map/testC.h:
    * examples/idl4/struct_inheritance/testC.h:
    * examples/local/testC.h:
    * examples/local/testS.h:
    * examples/objrefarg/testC.h:
    * examples/radartrack/testC.h:
    * examples/sequence/testC.h:
    * examples/struct/testC.h:
    * examples/union/testC.h:
    * examples/valuetype/testC.h:
    * examples/valuetype/testS.h:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated include guard identifiers across multiple header files in the examples directory
  - Standardized header file inclusion prevention mechanism

The changes appear to be primarily maintenance-related, focusing on updating include guard macros to ensure consistent and unique header file identification across various example implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->